### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include tests
+recursive-include docs
+recursive-include examples
+include LICENSE
+include Makefile


### PR DESCRIPTION
Tests, docs and license should be included in source distribution. They can be included with a [Manifest](https://packaging.python.org/en/latest/guides/using-manifest-in/) while still being excluded in bdist package.
This is allows for test to be fund and run with the Gentoo Linux package manager.