### PR TITLE
Fix testsuite for Python 3.14

### DIFF
--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -79,9 +79,10 @@ class HelpFormatterTestCase(unittest.TestCase):
         thehelp = parser.format_help()
 
         minor = sys.version_info.minor
+        synopsis = "[-p | --plain | -j | --json]" if minor < 14 else "[-h] [-p | -j]"
         optstr = "options" if minor >= 10 else "optional arguments"
         exp = (
-            f"usage: test [-p | --plain | -j | --json]\n\n{optstr}:\n"
+            f"usage: test {synopsis}\n\n{optstr}:\n"
             "  -h, --help   show this help message and exit\n"
             "  -p, --plain  plain help\n"
             "  -j, --json   json help\n"


### PR DESCRIPTION
As documented in this [bug report in Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1127531), the testsuite is currently failing with Python 3.14 with this error:

```
======================================================================
FAIL: test__format_actions_usage_1 (tests.test_formatter.HelpFormatterTestCase.test__format_actions_usage_1)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.14/build/tests/test_formatter.py", line 89, in test__format_actions_usage_1
    self.assertEqual(thehelp, exp)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
AssertionError: 'usage: test [-h] [-p | -j]\n\noptions:\n  -h, --help   [82 chars]lp\n' != 'usage: test [-p | --plain | -j | --json]\n\noptions:\n [96 chars]lp\n'
- usage: test [-h] [-p | -j]
+ usage: test [-p | --plain | -j | --json]
  
  options:
    -h, --help   show this help message and exit
    -p, --plain  plain help
    -j, --json   json help
```

This patch (I'm not the author) should fix the issue.